### PR TITLE
feat: add reusable Card UI components

### DIFF
--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface CardProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Card({ children, className }: CardProps) {
+  return (
+    <div className={cn('rounded-md border border-gray-300 bg-white p-4', className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Card/CardContent.tsx
+++ b/src/components/ui/Card/CardContent.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface CardContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CardContent({ children, className }: CardContentProps) {
+  return <div className={cn(className)}>{children}</div>;
+}

--- a/src/components/ui/Card/CardDescription.tsx
+++ b/src/components/ui/Card/CardDescription.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface CardDescriptionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CardDescription({ children, className }: CardDescriptionProps) {
+  return <p className={cn('my-2 text-sm text-gray-600', className)}>{children}</p>;
+}

--- a/src/components/ui/Card/CardHeader.tsx
+++ b/src/components/ui/Card/CardHeader.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface CardHeaderProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CardHeader({ children, className }: CardHeaderProps) {
+  return <div className={cn('flex flex-col space-y-1', className)}>{children}</div>;
+}

--- a/src/components/ui/Card/CardTitle.tsx
+++ b/src/components/ui/Card/CardTitle.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface CardTitleProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CardTitle({ children, className }: CardTitleProps) {
+  return (
+    <h3
+      className={cn(
+        'flex items-center gap-2 text-2xl leading-none font-semibold tracking-tight',
+        className
+      )}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/src/components/ui/Card/index.ts
+++ b/src/components/ui/Card/index.ts
@@ -1,0 +1,5 @@
+export { default as Card } from '@/components/ui/Card/Card';
+export { default as CardContent } from '@/components/ui/Card/CardContent';
+export { default as CardDescription } from '@/components/ui/Card/CardDescription';
+export { default as CardHeader } from '@/components/ui/Card/CardHeader';
+export { default as CardTitle } from '@/components/ui/Card/CardTitle';


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #7 

### 📌 설명

다음 작업을 진행한 Pull Request입니다.

- 프로젝트 전반에서 일관되게 사용할 수 있는 Card UI 컴포넌트와 관련 서브 컴포넌트(CardHeader, CardTitle, CardContent, CardDescription)를 구현합니다. 각 컴포넌트는 className prop을 지원하여 유연하게 커스터마이징할 수 있습니다.

### 📃 작업 사항

- [x] Card 컴포넌트 생성
- [x] CardHeader 컴포넌트 생성
- [x] CardTitle 컴포넌트 생성
- [x] CardContent 컴포넌트 생성
- [x] CardDescription 컴포넌트 생성
- [x] index.ts를 통한 컴포넌트 통합 및 export

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a set of Card UI components, including Card, CardContent, CardDescription, CardHeader, and CardTitle, for building customizable card layouts in the application. These components offer flexible styling and structure for displaying grouped content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->