### PR TITLE
feat: add accessibility analysis result and ResultViewer

### DIFF
--- a/public/eye.svg
+++ b/public/eye.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye h-5 w-5"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,38 @@
 import Image from 'next/image';
 
 import ClientEditorWrapper from '@/components/ClientEditorWrapper';
+import ResultViewer from '@/components/ResultViewer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 
 export default function Home() {
   return (
     <div className="mt-20">
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            <Image src="/code.svg" alt="코드 아이콘" width={24} height={24} priority />
-            코드 입력
-          </CardTitle>
-          <CardDescription>React 또는 Next.js 컴포넌트 코드를 입력하세요</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ClientEditorWrapper />
-        </CardContent>
-      </Card>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Image src="/code.svg" alt="코드 아이콘" width={24} height={24} priority />
+              코드 입력
+            </CardTitle>
+            <CardDescription>React 또는 Next.js 컴포넌트 코드를 입력하세요</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ClientEditorWrapper />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Image src="/eye.svg" alt="결과 아이콘" width={24} height={24} priority />
+              분석 결과
+            </CardTitle>
+            <CardDescription>React 또는 Next.js 컴포넌트 코드를 입력하세요</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResultViewer />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
               <Image src="/eye.svg" alt="결과 아이콘" width={24} height={24} priority />
               분석 결과
             </CardTitle>
-            <CardDescription>React 또는 Next.js 컴포넌트 코드를 입력하세요</CardDescription>
+            <CardDescription>스크린 리더 대본과 접근성 이슈를 확인하세요</CardDescription>
           </CardHeader>
           <CardContent>
             <ResultViewer />

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -20,13 +20,13 @@ export default function ResultViewer() {
     <div className="h-[370px] overflow-scroll">
       <ul className="space-y-2 text-sm text-gray-700">
         {formatted.map((item, idx) => (
-          <div key={idx} className="flex gap-3 rounded-lg bg-gray-50 p-3">
+          <li key={idx} className="flex gap-3 rounded-lg bg-gray-50 p-3">
             <div className="flex items-center">{idx + 1}</div>
             <div className="flex-1">
               <div className="text-md font-semibold">{item[1]}</div>
               <div className="mt-1 text-sm text-gray-500">{item[0]}</div>
             </div>
-          </div>
+          </li>
         ))}
       </ul>
     </div>

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useResultStore } from '@/stores/useResultStore';
+import formatResultsForDisplay from '@/utils/format/formatResultsForDisplay';
+
+export default function ResultViewer() {
+  const result = useResultStore((state) => state.result);
+
+  if (!result || !Array.isArray(result.script) || result.script.length === 0) {
+    return (
+      <div className="flex h-[370px] items-center justify-center text-gray-500">
+        코드를 입력하고 분석 버튼을 클릭하세요
+      </div>
+    );
+  }
+
+  const formatted = formatResultsForDisplay(result.script);
+
+  return (
+    <div className="h-[370px] overflow-scroll">
+      <ul className="space-y-2 text-sm text-gray-700">
+        {formatted.map((item, idx) => (
+          <div key={idx} className="flex gap-3 rounded-lg bg-gray-50 p-3">
+            <div className="flex items-center">{idx + 1}</div>
+            <div className="flex-1">
+              <div className="text-md font-semibold">{item[1]}</div>
+              <div className="mt-1 text-sm text-gray-500">{item[0]}</div>
+            </div>
+          </div>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/stores/useResultStore.js
+++ b/src/stores/useResultStore.js
@@ -4,7 +4,7 @@ import { persist } from 'zustand/middleware';
 export const useResultStore = create(
   persist(
     (set) => ({
-      result: [],
+      result: { script: [] },
 
       setResult: (result) => set({ result }),
     }),

--- a/src/stores/useResultStore.js
+++ b/src/stores/useResultStore.js
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useResultStore = create(
+  persist(
+    (set) => ({
+      result: [],
+
+      setResult: (result) => set({ result }),
+    }),
+    {
+      name: 'result-storage',
+    }
+  )
+);

--- a/src/utils/format/formatAsScreenReaderScript.ts
+++ b/src/utils/format/formatAsScreenReaderScript.ts
@@ -1,0 +1,42 @@
+import { AccessibleElement } from '@/utils/ast/analyzeAccessibility';
+
+export function formatAsScreenReaderScript(elements: AccessibleElement[]): string[] {
+  return elements.map((el) => {
+    const { tag, text, props } = el;
+
+    const name = props['aria-label'] || text || props['alt'] || '';
+
+    if (/^h[1-6]$/.test(tag)) {
+      const level = tag[1];
+      return `헤딩 레벨 ${level}: "${name}"`;
+    }
+
+    if (['nav', 'main', 'header', 'footer', 'aside'].includes(tag)) {
+      const label = props['aria-label'] ? ` (label: "${props['aria-label']}")` : '';
+      return `랜드마크 영역: ${tag}${label}`;
+    }
+
+    if (tag === 'img') {
+      return props['alt'] ? `이미지: "${props['alt']}"` : `이미지: (대체 텍스트 없음)`;
+    }
+
+    if (tag === 'a') {
+      return `링크: "${name}"`;
+    }
+
+    if (tag === 'input') {
+      const placeholder = props['placeholder'] ? ` (placeholder: "${props['placeholder']}")` : '';
+      return `입력 필드: "${name}"${placeholder}`;
+    }
+
+    if (tag === 'button') {
+      const state =
+        props['aria-pressed'] !== undefined
+          ? ` (상태: ${props['aria-pressed'] === 'true' ? '선택됨' : '선택되지 않음'})`
+          : '';
+      return `버튼: "${name}"${state}`;
+    }
+
+    return `${tag} 요소: "${name}"`;
+  });
+}

--- a/src/utils/format/formatResultsForDisplay.ts
+++ b/src/utils/format/formatResultsForDisplay.ts
@@ -1,0 +1,23 @@
+export default function formatResultsForDisplay(rawResults: string[]): string[][] {
+  return rawResults.map((line) => {
+    const [type, ...restParts] = line.split(': ');
+    const restRaw = restParts.join(': ').trim();
+
+    const placeholderMatch = restRaw.match(/\(placeholder: "(.*?)"\)/);
+    const placeholder = placeholderMatch?.[1];
+
+    const cleanedText = restRaw
+      .replace(/\(placeholder: ".*?"\)/, '')
+      .replace(/^"+|"+$/g, '')
+      .trim();
+
+    const content = cleanedText || placeholder || '';
+    const result = [type, content];
+
+    if (placeholder) {
+      result.push(placeholder);
+    }
+
+    return result;
+  });
+}


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #13 

### 📌 설명

다음 작업을 진행한 Pull Request입니다.

- 접근성 분석 결과를 시각적으로 확인할 수 있는 ResultViewer 컴포넌트를 추가합니다.
- 사용자가 "접근성 분석" 버튼을 클릭하면 분석 결과가 홈페이지 우측 분석 결과에 표시됩니다.
- 분석 결과는 스크린 리더 관점에서 해석된 텍스트로 렌더링됩니다.

### 📃 작업 사항

- [x] ResultViewer 컴포넌트 생성
- [x] zustand 기반 result 상태 저장소 구현 (`useResultStore`)
- [x] 스크린 리더 대본 형식 변환 유틸 함수 작성 (`formatAsScreenReaderScript`)
- [x] 분석 결과 출력 형식 변환 유틸 함수 작성 (`formatResultsForDisplay`)
- [x] 기존 페이지에 ResultViewer UI 통합
- [x] 분석 아이콘용 eye.svg 추가

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a two-column layout for simultaneous code input and analysis result viewing on large screens.
  * Added a new analysis results panel displaying formatted, scrollable results.
  * Implemented persistent storage for analysis results, retaining them across sessions.

* **Enhancements**
  * Improved accessibility by formatting analysis results for screen reader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->