### PR TITLE
feat: add reusable Tabs UI components

### DIFF
--- a/src/components/ui/Tabs/Tabs.tsx
+++ b/src/components/ui/Tabs/Tabs.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface TabsProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Tabs({ children, className }: TabsProps) {
+  return (
+    <div dir="ltr" className={cn(className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Tabs/TabsContent.tsx
+++ b/src/components/ui/Tabs/TabsContent.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+import { useResultStore } from '@/stores/useResultStore';
+import { cn } from '@/utils/cn';
+
+interface TabsContentProps {
+  children: ReactNode;
+  className?: string;
+  value: string;
+}
+
+export default function TabsContent({ children, className, value }: TabsContentProps) {
+  const selectedTab = useResultStore((state) => state.selectedTab);
+
+  if (selectedTab !== value) {
+    return null;
+  }
+
+  return <div className={cn(className)}>{children}</div>;
+}

--- a/src/components/ui/Tabs/TabsList.tsx
+++ b/src/components/ui/Tabs/TabsList.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface TabsListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function TabsList({ children, className }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      aria-orientation="horizontal"
+      className={cn('items-center justify-center rounded-md bg-gray-100 p-1', className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Tabs/TabsTrigger.tsx
+++ b/src/components/ui/Tabs/TabsTrigger.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+import { useResultStore } from '@/stores/useResultStore';
+import { cn } from '@/utils/cn';
+
+interface TabsTriggerProps {
+  children: ReactNode;
+  className?: string;
+  value: string;
+}
+
+export default function TabsTrigger({ children, className, value }: TabsTriggerProps) {
+  const selectedTab = useResultStore((state) => state.selectedTab);
+  const setSelectedTab = useResultStore((state) => state.setSelectedTab);
+  const isActive = selectedTab === value;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      className={cn(
+        'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all',
+        isActive ? 'bg-white' : 'text-muted-foreground',
+        className
+      )}
+      onClick={() => setSelectedTab(value)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Tabs/TabsTrigger.tsx
+++ b/src/components/ui/Tabs/TabsTrigger.tsx
@@ -19,12 +19,20 @@ export default function TabsTrigger({ children, className, value }: TabsTriggerP
       type="button"
       role="tab"
       aria-selected={isActive}
+      aria-controls={`tabpanel-${value}`}
+      tabIndex={isActive ? 0 : -1}
       className={cn(
         'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all',
         isActive ? 'bg-white' : 'text-muted-foreground',
         className
       )}
       onClick={() => setSelectedTab(value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setSelectedTab(value);
+        }
+      }}
     >
       {children}
     </button>

--- a/src/components/ui/Tabs/index.ts
+++ b/src/components/ui/Tabs/index.ts
@@ -1,0 +1,4 @@
+export { default as Tabs } from '@/components/ui/Tabs/Tabs';
+export { default as TabsContent } from '@/components/ui/Tabs/TabsContent';
+export { default as TabsList } from '@/components/ui/Tabs/TabsList';
+export { default as TabsTrigger } from '@/components/ui/Tabs/TabsTrigger';

--- a/src/stores/useResultStore.js
+++ b/src/stores/useResultStore.js
@@ -5,8 +5,10 @@ export const useResultStore = create(
   persist(
     (set) => ({
       result: { script: [] },
+      selectedTab: 'script',
 
       setResult: (result) => set({ result }),
+      setSelectedTab: (tab) => set({ selectedTab: tab }),
     }),
     {
       name: 'result-storage',


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #15 

### 📌 설명

다음 작업을 진행한 Pull Request입니다.

- 프로젝트 전반에서 일관되게 사용할 수 있는 Tabs UI 컴포넌트와 관련 서브 컴포넌트(TabsContent, TabsList, TabsTrigger)를 구현합니다.
- 각 컴포넌트는 className prop을 지원하여 유연하게 커스터마이징할 수 있습니다.
- useResultStore에 선택된 탭 상태를 저장하고 변경합니다.

### 📃 작업 사항

- [x] Tabs 컴포넌트 생성
- [x] TabsContent 컴포넌트 생성
- [x] TabsList 컴포넌트 생성
- [x] TabsTrigger 컴포넌트 생성
- [x] index.ts를 통한 컴포넌트 통합 및 export
- [x] `useResultStore`에 선택된 탭 상태를 저장하고 변경하는 `selectedTab`과 `setSelectedTab` 추가

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a set of tabbed interface components, allowing users to navigate between different content sections using tabs.
  * Tabs now display content conditionally based on the selected tab, enhancing organization and user experience.
  * Improved accessibility for tab navigation with appropriate ARIA attributes.

* **Chores**
  * Centralized exports for tab components to simplify imports throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->