### PR TITLE
feat: add login page UI with social login and guest mode

### DIFF
--- a/public/arrow-left.svg
+++ b/public/arrow-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-left h-4 w-4"><path d="m12 19-7-7 7-7"></path><path d="M19 12H5"></path></svg>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -44,7 +44,7 @@ export default function Login() {
               <span className="bg-white px-2 text-xs text-gray-500">또는</span>
             </div>
           </div>
-          <Button variant="outline" className="h-12 w-full">
+          <Button variant="outline" className="h-12 w-full" asChild>
             <Link href="/">
               게스트로 계속하기
               <span className="ml-2 text-xs text-gray-500">(결과 저장 불가)</span>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,57 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import Button from '@/components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import Separator from '@/components/ui/Separator';
+
 export default function Login() {
-  return <div>Login</div>;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-white to-green-50">
+      <div className="absolute top-4 left-4">
+        <Link href="/" className="flex items-center gap-2 font-medium">
+          <Image src="/arrow-left.svg" alt="돌아가기 아이콘" width={16} height={16} priority />
+          돌아가기
+        </Link>
+      </div>
+
+      <Card className="h-1/5 w-1/4 border-0 shadow-lg">
+        <CardHeader className="pb-4 text-center">
+          <CardTitle className="w-full justify-center text-xl">시작하기</CardTitle>
+          <CardDescription>
+            카카오 계정으로 간편하게 로그인하고
+            <br />
+            분석 결과를 저장하고 관리하세요
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Button className="h-12 w-full border-0 bg-[#FEE500] text-base font-medium text-black shadow-sm hover:bg-[#FDD835]">
+            <div className="flex items-center gap-3">
+              <svg width="18" height="17" viewBox="0 0 18 17" fill="none">
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M8.99999 0.333374C13.7844 0.333374 17.6667 3.58671 17.6667 7.58337C17.6667 9.94171 16.4289 12.0417 14.4822 13.3334L13.1111 16.6667L9.33333 14.1667C9.22222 14.1667 9.11111 14.1667 8.99999 14.1667C4.21555 14.1667 0.333328 10.9134 0.333328 6.91671C0.333328 3.25004 4.21555 0.333374 8.99999 0.333374Z"
+                  fill="black"
+                />
+              </svg>
+              카카오로 시작하기
+            </div>
+          </Button>
+          <div className="relative">
+            <Separator />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="bg-white px-2 text-xs text-gray-500">또는</span>
+            </div>
+          </div>
+          <Button variant="outline" className="h-12 w-full">
+            <Link href="/">
+              게스트로 계속하기
+              <span className="ml-2 text-xs text-gray-500">(결과 저장 불가)</span>
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,7 +1,9 @@
+import { Slot } from '@/components/ui/Slot';
 import { cn } from '@/utils/cn';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'default' | 'secondary' | 'outline';
+  asChild?: boolean;
 }
 
 const variantClasses: Record<NonNullable<ButtonProps['variant']>, string> = {
@@ -16,10 +18,12 @@ export default function Button({
   disabled,
   variant = 'default',
   className,
+  asChild = false,
 }: ButtonProps) {
+  const Comp = asChild ? Slot : 'button';
+
   return (
-    <button
-      type="button"
+    <Comp
       className={cn(
         'inline-flex h-10 w-full items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
         variantClasses[variant],
@@ -29,6 +33,6 @@ export default function Button({
       disabled={disabled}
     >
       {children}
-    </button>
+    </Comp>
   );
 }

--- a/src/components/ui/Separator.tsx
+++ b/src/components/ui/Separator.tsx
@@ -1,0 +1,3 @@
+export default function Separator() {
+  return <div role="none" className="h-[1] w-full border-[1] border-gray-100"></div>;
+}

--- a/src/components/ui/Slot.tsx
+++ b/src/components/ui/Slot.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface SlotProps extends React.HTMLAttributes<HTMLElement> {
+  children?: React.ReactNode;
+}
+
+const Slot = React.forwardRef<HTMLElement, SlotProps>(({ children, ...props }, ref) => {
+  if (React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...props,
+      ...children.props,
+      ref,
+      className: [props.className, children.props.className].filter(Boolean).join(' '),
+    });
+  }
+
+  if (React.Children.count(children) > 1) {
+    React.Children.only(null);
+  }
+
+  return null;
+});
+
+Slot.displayName = 'Slot';
+
+export { Slot };


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #23 

### 📌 설명

다음 작업을 진행한 Pull Request입니다.

- 로그인 페이지 UI 작업입니다.
- 카카오 소셜 로그인 버튼과 게스트 모드 버튼을 포함한 로그인 화면을 구성했습니다.

### 📃 작업 사항

- [x] 돌아가기 버튼 및 아이콘 추가
- [x] 로그인 페이지 전체 UI 마크업 및 스타일링
- [x] 카카오 로그인 버튼 UI 구현
- [x] Separator 컴포넌트 생성 및 사용
- [x] 게스트로 진행하기 버튼 추가

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a fully designed login page with options to log in via Kakao or as a guest.
  * Added a visually styled separator component for improved UI layout.
  * Enhanced button component to support flexible rendering through a new compositional mode.
  * Added a slot component to enable advanced UI composition with ref forwarding.

* **Style**
  * Enhanced the login page with modern styling, including a gradient background, card layout, and clear navigation elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->