### PR TITLE
feat: add reusable Select UI components

### DIFF
--- a/public/check.svg
+++ b/public/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check-icon lucide-check"><path d="M20 6 9 17l-5-5"/></svg>

--- a/public/chevron-down.svg
+++ b/public/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down h-4 w-4 opacity-50" aria-hidden="true"><path d="m6 9 6 6 6-6"></path></svg>

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Children, ReactNode, isValidElement, useMemo, useState } from 'react';
+
+import { SelectProvider } from '@/components/ui/Select/context';
+
+interface SelectProps {
+  children: ReactNode;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export default function Select({ children, defaultValue, onValueChange }: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(defaultValue);
+
+  const [trigger, content] = Children.toArray(children);
+
+  const optionsMap = useMemo(() => {
+    const map = new Map<string, ReactNode>();
+
+    if (isValidElement(content)) {
+      const contentElement = content as React.ReactElement<{ children?: ReactNode }>;
+
+      Children.forEach(contentElement.props.children, (child) => {
+        if (isValidElement(child)) {
+          const childElement = child as React.ReactElement<{ value: string; children?: ReactNode }>;
+          const value = childElement.props.value;
+
+          if (value) {
+            map.set(value, childElement.props.children);
+          }
+        }
+      });
+    }
+
+    return map;
+  }, [content]);
+
+  const handleValueChange = (value: string) => {
+    setSelectedValue(value);
+    onValueChange?.(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <SelectProvider
+      value={{
+        isOpen,
+        setIsOpen,
+        selectedValue,
+        onValueChange: handleValueChange,
+        optionsMap,
+      }}
+    >
+      <div className="relative">
+        {trigger}
+        {isOpen && content}
+      </div>
+    </SelectProvider>
+  );
+}

--- a/src/components/ui/Select/SelectContent.tsx
+++ b/src/components/ui/Select/SelectContent.tsx
@@ -17,6 +17,8 @@ export default function SelectContent({ children, className }: SelectContentProp
 
   return (
     <div
+      role="listbox"
+      aria-expanded={isOpen}
       className={cn(
         'absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white p-1 shadow-md',
         className

--- a/src/components/ui/Select/SelectContent.tsx
+++ b/src/components/ui/Select/SelectContent.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+import { useSelectContext } from '@/components/ui/Select/context';
+import { cn } from '@/utils/cn';
+
+interface SelectContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function SelectContent({ children, className }: SelectContentProps) {
+  const { isOpen } = useSelectContext();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'absolute z-50 mt-1 w-full rounded-md border border-gray-200 bg-white p-1 shadow-md',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Select/SelectItem.tsx
+++ b/src/components/ui/Select/SelectItem.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import { ReactNode } from 'react';
+
+import { useSelectContext } from '@/components/ui/Select/context';
+import { cn } from '@/utils/cn';
+
+interface SelectItemProps {
+  children: ReactNode;
+  className?: string;
+  value: string;
+}
+
+export default function SelectItem({ children, className, value }: SelectItemProps) {
+  const { selectedValue, onValueChange } = useSelectContext();
+
+  return (
+    <div
+      className={cn(
+        'relative flex w-full cursor-default items-center rounded-sm border border-transparent py-1.5 pr-2 pl-2 text-sm outline-none select-none hover:border-black hover:bg-gray-200 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      onClick={() => onValueChange(value)}
+    >
+      {selectedValue === value ? (
+        <Image
+          src="/check.svg"
+          alt="선택된 옵션 아이콘"
+          width={16}
+          height={16}
+          priority
+          className="mr-2"
+        />
+      ) : (
+        <div className="mr-2 w-4" />
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Select/SelectItem.tsx
+++ b/src/components/ui/Select/SelectItem.tsx
@@ -14,12 +14,18 @@ export default function SelectItem({ children, className, value }: SelectItemPro
   const { selectedValue, onValueChange } = useSelectContext();
 
   return (
-    <div
+    <button
+      type="button"
+      role="option"
+      aria-selected={selectedValue === value}
       className={cn(
         'relative flex w-full cursor-default items-center rounded-sm border border-transparent py-1.5 pr-2 pl-2 text-sm outline-none select-none hover:border-black hover:bg-gray-200 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className
       )}
-      onClick={() => onValueChange(value)}
+      onClick={(e) => {
+        e.stopPropagation();
+        onValueChange(value);
+      }}
     >
       {selectedValue === value ? (
         <Image
@@ -34,6 +40,6 @@ export default function SelectItem({ children, className, value }: SelectItemPro
         <div className="mr-2 w-4" />
       )}
       {children}
-    </div>
+    </button>
   );
 }

--- a/src/components/ui/Select/SelectTrigger.tsx
+++ b/src/components/ui/Select/SelectTrigger.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import { ReactNode } from 'react';
+
+import { useSelectContext } from '@/components/ui/Select/context';
+import { cn } from '@/utils/cn';
+
+interface SelectTriggerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function SelectTrigger({ children, className }: SelectTriggerProps) {
+  const { isOpen, setIsOpen } = useSelectContext();
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex h-10 w-full items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      onClick={() => setIsOpen(!isOpen)}
+    >
+      {children}
+      <Image
+        src="/chevron-down.svg"
+        alt="선택 탭 열기 아이콘"
+        width={16}
+        height={16}
+        priority
+        className="mr-2"
+      />
+    </button>
+  );
+}

--- a/src/components/ui/Select/SelectTrigger.tsx
+++ b/src/components/ui/Select/SelectTrigger.tsx
@@ -15,6 +15,8 @@ export default function SelectTrigger({ children, className }: SelectTriggerProp
   return (
     <button
       type="button"
+      aria-expanded={isOpen}
+      aria-haspopup="listbox"
       className={cn(
         'flex h-10 w-full items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
         className
@@ -24,10 +26,9 @@ export default function SelectTrigger({ children, className }: SelectTriggerProp
       {children}
       <Image
         src="/chevron-down.svg"
-        alt="선택 탭 열기 아이콘"
+        alt="스크린 리더 선택 드롭다운 확장 아이콘"
         width={16}
         height={16}
-        priority
         className="mr-2"
       />
     </button>

--- a/src/components/ui/Select/SelectValue.tsx
+++ b/src/components/ui/Select/SelectValue.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+import { useSelectContext } from '@/components/ui/Select/context';
+
+interface SelectValueProps {
+  placeholder?: ReactNode;
+}
+
+export default function SelectValue({ placeholder }: SelectValueProps) {
+  const { selectedValue, optionsMap } = useSelectContext();
+
+  const displayValue = selectedValue ? optionsMap.get(selectedValue) : undefined;
+
+  return <>{displayValue || placeholder}</>;
+}

--- a/src/components/ui/Select/context.tsx
+++ b/src/components/ui/Select/context.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface SelectContextType {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  selectedValue?: string;
+  onValueChange: (value: string) => void;
+  optionsMap: Map<string, React.ReactNode>;
+}
+
+export const SelectContext = createContext<SelectContextType | undefined>(undefined);
+
+export function useSelectContext() {
+  const context = useContext(SelectContext);
+
+  if (!context) {
+    throw new Error('useSelectContext must be used within a SelectProvider');
+  }
+
+  return context;
+}
+
+export function SelectProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: SelectContextType;
+}) {
+  return <SelectContext.Provider value={value}>{children}</SelectContext.Provider>;
+}

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,5 @@
+export { default as Select } from '@/components/ui/Select/Select';
+export { default as SelectContent } from '@/components/ui/Select/SelectContent';
+export { default as SelectItem } from '@/components/ui/Select/SelectItem';
+export { default as SelectTrigger } from '@/components/ui/Select/SelectTrigger';
+export { default as SelectValue } from '@/components/ui/Select/SelectValue';


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #27 

### 📌 설명

다음 작업을 진행한 Pull Request입니다.

- 프로젝트 전반에서 일관되게 사용할 수 있는 Select UI 컴포넌트와 관련 서브 컴포넌트(SelectContent, SelectItem, SelectTrigger, SelectValue)를 구현합니다.
- 각 컴포넌트는 className prop을 지원하여 유연하게 커스터마이징할 수 있습니다.

### 📃 작업 사항

- [x] Select 컴포넌트 내부의 상태를 관리하는 context.tsx 생성
- [x] Select 생성
- [x] SelectContent 생성
- [x] SelectItem 생성
- [x] SelectTrigger 생성
- [x] SelectValue 생성

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a customizable Select dropdown component with support for selectable items, triggers, and value display.
  * Added components for dropdown content, selectable items, trigger button, and value/placeholder display.
  * Enabled easy integration and centralized importing of Select-related UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->