### PR TITLE
feat: add global toast system and apply it to user actions

### DIFF
--- a/src/app/auth/kakao/callback/page.tsx
+++ b/src/app/auth/kakao/callback/page.tsx
@@ -4,11 +4,13 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 
 export default function KakaoCallback() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { login } = useAuth();
+  const { showToast } = useToast();
 
   useEffect(() => {
     const code = searchParams.get('code');
@@ -37,17 +39,17 @@ export default function KakaoCallback() {
           }
         } catch (error) {
           console.error('카카오 로그인 처리 실패:', error);
-          alert('로그인에 실패했습니다. 다시 시도해주세요.');
+          showToast({ message: '로그인에 실패했습니다. 다시 시도해주세요.' });
           router.replace('/login');
         }
       }
 
       sendCodeToBackend();
     } else {
-      alert('비정상적인 접근입니다.');
+      showToast({ message: '비정상적인 접근입니다.' });
       router.replace('/login');
     }
-  }, [searchParams, router, login]);
+  }, [searchParams, router, login, showToast]);
 
   return (
     <div className="flex h-screen w-full items-center justify-center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import localFont from 'next/font/local';
 
 import { AuthProvider } from '@/contexts/AuthContext';
+import { ToastProvider } from '@/contexts/ToastContext';
 
 import type { Metadata } from 'next';
 import './globals.css';
@@ -26,7 +27,9 @@ export default function RootLayout({
     <html lang="ko" className={`${pretendard.variable}`}>
       <body className={`${pretendard.className} min-h-dvh w-full`}>
         <AuthProvider>
-          <main>{children}</main>
+          <ToastProvider>
+            <main>{children}</main>
+          </ToastProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/AccessibilityAnalyzer.tsx
+++ b/src/components/AccessibilityAnalyzer.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/Select';
 import { TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { useTabsContext } from '@/components/ui/Tabs/context';
+import { useToast } from '@/contexts/ToastContext';
 import { useAnalysisStore } from '@/stores/useAnalysisStore';
 import { useInputStore } from '@/stores/useInputStore';
 
@@ -27,17 +28,18 @@ function AccessibilityAnalyzerContent() {
   const url = useInputStore((state) => state.url);
   const setUrl = useInputStore((state) => state.setUrl);
   const { analyze, isLoading, selectedScreenReader, setSelectedScreenReader } = useAnalysisStore();
+  const { showToast } = useToast();
 
   async function handleAnalysisClick() {
     if (selectedTab === 'code') {
       if (!code) {
-        alert('코드를 입력해주세요.');
+        showToast({ message: '코드를 입력해주세요.' });
         return;
       }
       await analyze({ htmlContent: code });
     } else {
       if (!url) {
-        alert('URL을 입력해주세요.');
+        showToast({ message: 'URL을 입력해주세요.' });
         return;
       }
       await analyze({ url });

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -8,6 +8,7 @@ import ScreenReaderScript from '@/components/ResultViewer/ScreenReaderScript';
 import Button from '@/components/ui/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 import { useAnalysisStore } from '@/stores/useAnalysisStore';
 
 export default function ResultViewer({ showShareButton = true }: { showShareButton?: boolean }) {
@@ -19,6 +20,7 @@ export default function ResultViewer({ showShareButton = true }: { showShareButt
   const [isSaved, setIsSaved] = useState(false);
 
   const { isLoggedIn } = useAuth();
+  const { showToast } = useToast();
 
   const iframeSrc = useMemo(() => {
     if (!pageContent) {
@@ -40,7 +42,7 @@ export default function ResultViewer({ showShareButton = true }: { showShareButt
 
   async function handleSaveResult() {
     if (!analysisResult || !pageContent || !screenReaderScript) {
-      alert('분석할 URL 또는 HTML 콘텐츠가 없습니다. 먼저 분석을 수행해주세요.');
+      showToast({ message: '분석할 URL 또는 HTML 콘텐츠가 없습니다. 먼저 분석을 수행해주세요.' });
 
       return;
     }
@@ -77,7 +79,7 @@ export default function ResultViewer({ showShareButton = true }: { showShareButt
       setIsSaved(true);
     } catch (error) {
       const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
-      alert(message);
+      showToast({ message });
     } finally {
       setIsSaving(false);
     }
@@ -89,10 +91,10 @@ export default function ResultViewer({ showShareButton = true }: { showShareButt
     }
     try {
       await navigator.clipboard.writeText(shareableLink);
-      alert('공유 링크가 클립보드에 복사되었습니다.');
+      showToast({ message: '공유 링크가 클립보드에 복사되었습니다.' });
     } catch (error) {
       console.error('클립보드 복사 실패:', error);
-      alert('링크 복사에 실패했습니다. 브라우저 설정을 확인해주세요.');
+      showToast({ message: '링크 복사에 실패했습니다. 브라우저 설정을 확인해주세요.' });
     }
   }
 

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -90,7 +90,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
           {placementToasts.map((toast) => (
             <div
               key={toast.id}
-              className="animate-fade-in relative w-fit max-w-[90vw] min-w-40 rounded border border-gray-200 bg-white py-2 pr-8 pl-4 text-gray-800 shadow-md"
+              className="relative w-fit max-w-[90vw] min-w-40 rounded border border-gray-200 bg-white py-2 pr-8 pl-4 text-gray-800 shadow-md"
             >
               <p className="font-sans text-sm">{toast.message}</p>
               <button

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import { createContext, useContext, useState, ReactNode, useCallback, useMemo } from 'react';
 
 export const TOAST_PLACEMENTS = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight'] as const;
 
@@ -68,14 +68,16 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
     [removeToast]
   );
 
-  const toastsByPlacement = toasts.reduce(
-    (acc, toast) => {
-      acc[toast.placement] = acc[toast.placement] || [];
-      acc[toast.placement].push(toast);
-      return acc;
-    },
-    {} as Record<ToastPlacement, ToastType[]>
-  );
+  const toastsByPlacement = useMemo(() => {
+    return toasts.reduce(
+      (acc, toast) => {
+        acc[toast.placement] = acc[toast.placement] || [];
+        acc[toast.placement].push(toast);
+        return acc;
+      },
+      {} as Record<ToastPlacement, ToastType[]>
+    );
+  }, [toasts]);
 
   return (
     <ToastContext.Provider value={{ showToast }}>

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -90,9 +90,16 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
           {placementToasts.map((toast) => (
             <div
               key={toast.id}
-              className="animate-fade-in relative w-fit max-w-[90vw] min-w-40 rounded border border-gray-200 bg-white px-4 py-2 text-gray-800 shadow-md"
+              className="animate-fade-in relative w-fit max-w-[90vw] min-w-40 rounded border border-gray-200 bg-white py-2 pr-8 pl-4 text-gray-800 shadow-md"
             >
               <p className="font-sans text-sm">{toast.message}</p>
+              <button
+                onClick={() => removeToast(toast.id)}
+                className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded-full p-1 text-lg text-gray-500 hover:bg-gray-100"
+                aria-label="알림 닫기"
+              >
+                ×
+              </button>
             </div>
           ))}
         </div>

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+
+export const TOAST_PLACEMENTS = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight'] as const;
+
+type ToastPlacement = (typeof TOAST_PLACEMENTS)[number];
+
+interface ToastType {
+  id: number;
+  message: string;
+  placement: ToastPlacement;
+}
+
+export interface ToastOptions {
+  message: string;
+  placement?: ToastPlacement;
+  duration?: number;
+}
+
+export interface ToastContextType {
+  showToast: (options: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+const getPlacementClass = (placement: ToastPlacement) => {
+  switch (placement) {
+    case 'topLeft':
+      return 'top-4 left-4';
+    case 'topRight':
+      return 'top-4 right-4';
+    case 'bottomLeft':
+      return 'bottom-4 left-4';
+    case 'bottomRight':
+      return 'bottom-4 right-4';
+  }
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+
+  return context;
+};
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+export const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toasts, setToasts] = useState<ToastType[]>([]);
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    ({ message, placement = 'topRight', duration = 3000 }: ToastOptions) => {
+      const id = Date.now();
+      setToasts((prevToasts) => [...prevToasts, { id, message, placement }]);
+
+      setTimeout(() => removeToast(id), duration);
+    },
+    [removeToast]
+  );
+
+  const toastsByPlacement = toasts.reduce(
+    (acc, toast) => {
+      acc[toast.placement] = acc[toast.placement] || [];
+      acc[toast.placement].push(toast);
+      return acc;
+    },
+    {} as Record<ToastPlacement, ToastType[]>
+  );
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {Object.entries(toastsByPlacement).map(([placement, placementToasts]) => (
+        <div
+          key={placement}
+          className={`fixed z-50 space-y-2 px-6 pt-16 ${getPlacementClass(
+            placement as ToastPlacement
+          )}`}
+        >
+          {placementToasts.map((toast) => (
+            <div
+              key={toast.id}
+              className="animate-fade-in relative w-fit max-w-[90vw] min-w-40 rounded border border-gray-200 bg-white px-4 py-2 text-gray-800 shadow-md"
+            >
+              <p className="font-sans text-sm">{toast.message}</p>
+            </div>
+          ))}
+        </div>
+      ))}
+    </ToastContext.Provider>
+  );
+};


### PR DESCRIPTION
### ✨ 이슈 번호

- closes #33

### 📌 설명

다음 작업을 진행한 Pull Request 입니다.

- 전역 토스트(Toast) 시스템을 구현하고 주요 사용자 액션에 적용하는 작업입니다.
- 기존 alert() 기반의 사용자 피드백 방식을 Toast로 교체하여 더 자연스럽고 일관된 UX를 제공합니다.
- 공유 링크 복사, 분석 요청, 로그인 실패 등 여러 곳에 적용되었습니다.

### 📃 작업 사항

- [x] ToastContext 생성 및 토스트 상태 관리 구현
- [x]  ToastProvider를 layout에 추가해 전역으로 적용
- [x] 공유 링크 복사 성공/실패 시 토스트 표시
- [x] 분석 요청 시 입력값 누락 안내를 alert → toast로 변경
- [x] 카카오 로그인 실패/비정상 접근 시 토스트로 오류 안내
- [x] useToast 훅을 통한 편리한 토스트 호출 방식 제공

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a toast notification system for user feedback across the application.
  * Toast notifications now appear for login events, missing input, save errors, and copy actions instead of browser alerts.

* **Refactor**
  * Replaced all alert dialogs with toast notifications for a more seamless and non-intrusive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->